### PR TITLE
create docker files and updated configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ secure.config
 mooclet_engine/requirements_latest_version.txt
 mooclet_engine/static
 
+# docker
+docker_local.env
+

--- a/mooclet_engine/docker_local.Dockerfile
+++ b/mooclet_engine/docker_local.Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.9-slim
+
+# Install PostgreSQL development headers for psycopg2
+ENV RPY2_CFFI_MODE=ABI
+RUN apt-get update && apt-get install -y \
+    libpq-dev gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./mooclet_engine/settings/secure.py /usr/src/app/
+COPY . .
+WORKDIR /
+
+RUN pip install psycopg2-binary==2.8.6
+RUN pip install --no-cache-dir -r requirements_latest_version.txt
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/mooclet_engine/docker_local.README.md
+++ b/mooclet_engine/docker_local.README.md
@@ -1,0 +1,69 @@
+# Mooclet Engine Local Development Setup
+
+The `docker_local` setup is gives a way to quickly start up a mooclet-engine instance to greatly reduce the setup and startup time.
+
+Launching `docker_local.docker-compose.yml` will:
+- Install all dependencies
+- Create an reusable image of the API
+- Run the Mooclet API and a postgres DB in a container
+- Create a super-user `mooclet` for immediate login
+
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Setup Instructions
+
+### 1. Clone the Repository (if you haven't already)
+
+```bash
+git clone https://github.com/Intelligent-Adaptive-Interventions-Lab/mooclet-engine.git
+cd mooclet-engine
+```
+---
+### 2. Environment Configuration
+
+#### Copy `secure.py.example`
+
+Copy the example secure configuration (or modify your existing `secure.py` to include the `docker_local` settings):
+
+```bash
+cp mooclet_engine/settings/secure.py.example mooclet_engine/settings/secure.py
+```
+
+Edit `secure.py` to use `docker_local` as default for local database:
+```python
+ACTIVE_DATABASE_CONFIG = 'docker_local'
+```
+---
+
+#### Copy `docker_local.env.example` env File
+
+These values are used in various spots in the docker setup. No edit needed unless you would like different values.
+
+```bash
+cp mooclet_engine/docker_local.env.example mooclet_engine/docker_local.env
+```
+---
+
+### 3. Run it!
+
+```bash
+docker-compose -f docker_local.docker-compose.yml up --build
+```
+
+#### To stop the Containers, do:
+```bash
+docker-compose -f docker_local.docker-compose.yml down
+```
+
+### 4. Accessing the Application and get API token
+
+- **Web Application**: http://localhost:8000
+- **Admin Panel**: http://localhost:8000/admin
+  - Username: `mooclet`
+  - Password: `mooclet`
+
+Navigate to `Tokens` to create a token for your API calls.

--- a/mooclet_engine/docker_local.docker-compose.yml
+++ b/mooclet_engine/docker_local.docker-compose.yml
@@ -3,28 +3,28 @@ services:
     image: postgres:alpine
     restart: always
     env_file:
-      - docker_local.env
+      - ./docker_local.env
     environment:
-      - POSTGRES_USER=${DB_USER}
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
-      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER:-moocletdb}
+      - POSTGRES_PASSWORD=${DB_PASSWORD:-mooclet}
+      - POSTGRES_DB=${DB_NAME:-moocletdb}
     networks:
       - moocletservice
     ports:
       - "5432:5432"
     volumes:
       - moocletdata:/var/lib/postgresql/data
-      - ./mooclet_local.docker_setup_sql.sh:/docker-entrypoint-initdb.d/mooclet_local.docker_setup_sql.sh
+      - ./docker_local.docker_setup_sql.sh:/docker-entrypoint-initdb.d/docker_local.docker_setup_sql.sh
 
   mooclet-api-local:
     container_name: mooclet-api-local
     build:
       context: .
-      dockerfile: ./mooclet_local.Dockerfile
+      dockerfile: ./docker_local.Dockerfile
     image: mooclet-api-local:latest
     pull_policy: never
     env_file:
-      - docker_local.env
+      - ./docker_local.env
     volumes:
       - moocletdata:/usr/mooclet_engine
     networks:
@@ -34,8 +34,8 @@ services:
     command: >
       sh -c "python manage.py migrate &&
              python manage.py loaddata policy &&
-             python manage.py createsuperuser --noinput --username=${DJANGO_SUPERUSER_USERNAME} --email=${DJANGO_SUPERUSER_EMAIL} || true &&
-             echo \"from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username='${DJANGO_SUPERUSER_USERNAME}'); user.set_password('${DJANGO_SUPERUSER_PASSWORD}'); user.save()\" | python manage.py shell &&
+             python manage.py createsuperuser --noinput --username=${DJANGO_SUPERUSER_USERNAME:-mooclet} --email=${DJANGO_SUPERUSER_EMAIL:-admin@mooclet.org} || true &&
+             echo \"from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username='${DJANGO_SUPERUSER_USERNAME:-mooclet}'); user.set_password('${DJANGO_SUPERUSER_PASSWORD:-mooclet}'); user.save()\" | python manage.py shell &&
              python manage.py runserver 0.0.0.0:8000"
     depends_on:
       - mooclet-postgres-local

--- a/mooclet_engine/docker_local.docker-compose.yml
+++ b/mooclet_engine/docker_local.docker-compose.yml
@@ -1,0 +1,48 @@
+services:
+  mooclet-postgres-local:
+    image: postgres:alpine
+    restart: always
+    env_file:
+      - docker_local.env
+    environment:
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
+    networks:
+      - moocletservice
+    ports:
+      - "5432:5432"
+    volumes:
+      - moocletdata:/var/lib/postgresql/data
+      - ./mooclet_local.docker_setup_sql.sh:/docker-entrypoint-initdb.d/mooclet_local.docker_setup_sql.sh
+
+  mooclet-api-local:
+    container_name: mooclet-api-local
+    build:
+      context: .
+      dockerfile: ./mooclet_local.Dockerfile
+    image: mooclet-api-local:latest
+    pull_policy: never
+    env_file:
+      - docker_local.env
+    volumes:
+      - moocletdata:/usr/mooclet_engine
+    networks:
+      - moocletservice 
+    ports:
+      - "8000:8000"
+    command: >
+      sh -c "python manage.py migrate &&
+             python manage.py loaddata policy &&
+             python manage.py createsuperuser --noinput --username=${DJANGO_SUPERUSER_USERNAME} --email=${DJANGO_SUPERUSER_EMAIL} || true &&
+             echo \"from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username='${DJANGO_SUPERUSER_USERNAME}'); user.set_password('${DJANGO_SUPERUSER_PASSWORD}'); user.save()\" | python manage.py shell &&
+             python manage.py runserver 0.0.0.0:8000"
+    depends_on:
+      - mooclet-postgres-local
+
+volumes:
+  moocletdata:
+
+networks:
+  moocletservice:
+    driver: "bridge"

--- a/mooclet_engine/docker_local.docker_setup_sql.sh
+++ b/mooclet_engine/docker_local.docker_setup_sql.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Use environment variables passed from .env file
+psql -v ON_ERROR_STOP=1 --username "$DB_USER" --dbname "$DB_NAME" <<-EOSQL
+  GRANT ALL PRIVILEGES ON DATABASE "$DB_NAME" TO "$DB_USER";
+EOSQL

--- a/mooclet_engine/docker_local.env.example
+++ b/mooclet_engine/docker_local.env.example
@@ -1,0 +1,11 @@
+# Database Configuration
+DB_NAME=moocletdb
+DB_USER=mooclet
+DB_PASSWORD=mooclet
+DB_HOST=mooclet-postgres-local
+DB_PORT=5432
+
+# Django Admin Superuser Configuration
+DJANGO_SUPERUSER_USERNAME=mooclet
+DJANGO_SUPERUSER_PASSWORD=mooclet
+DJANGO_SUPERUSER_EMAIL=admin@mooclet.org

--- a/mooclet_engine/mooclet_engine/settings/local.py
+++ b/mooclet_engine/mooclet_engine/settings/local.py
@@ -21,7 +21,7 @@ ALLOWED_HOSTS = ['*']
 # }
 
 DATABASES = {
-    'default': secure.LOCAL_DATABASE['dev'],
+    'default': secure.LOCAL_DATABASE[secure.ACTIVE_DATABASE_CONFIG],
 }
 
 

--- a/mooclet_engine/requirements_latest_version.txt
+++ b/mooclet_engine/requirements_latest_version.txt
@@ -29,9 +29,9 @@ jsonschema==2.6.0
 kombu==4.6.5
 MarkupSafe==1.1.1
 more-itertools==7.2.0
-numpy
+numpy==1.21.0
 openapi-spec-validator==0.2.8
-pandas
+pandas==1.3.0
 python-crontab==2.3.9
 python-dateutil==2.8.0
 pytz==2019.3

--- a/secure.py.example
+++ b/secure.py.example
@@ -30,9 +30,30 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__)) + '/mooclet_engine/mooclet
 
 LOCAL_DATABASE = {
     'dev': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3')
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': '',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': 'localhost',
+        'PORT': 5432,
+    },
+    'docker_local': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('DB_NAME', 'moocletdb'),
+        'USER': os.getenv('DB_USER', 'mooclet'),
+        'PASSWORD': os.getenv('DB_PASSWORD', 'mooclet'),
+        'HOST': os.getenv('DB_HOST', 'mooclet-postgres-local'),
+        'PORT': os.getenv('DB_PORT', 5432),
     }
+}
+
+# Choose which database configuration to use
+# Options: 'dev' or 'docker_local'
+ACTIVE_DATABASE_CONFIG = 'dev'
+
+# Actual database configuration
+DATABASES = {
+    'default': LOCAL_DATABASE[ACTIVE_DATABASE_CONFIG]
 }
 
 LOCAL_CELERY_BROKER_URL = None


### PR DESCRIPTION
From the associated `docker_local.README.md`:

# Mooclet Engine Local Development Setup

The `docker_local` setup is gives a way to quickly start up a mooclet-engine instance to greatly reduce the setup and startup time.

Launching `docker_local.docker-compose.yml` will:
- Install all dependencies
- Create an reusable image of the API
- Run the Mooclet API and a postgres DB in a container
- Create a super-user `mooclet` for immediate login


## Prerequisites

- Docker
- Docker Compose

## Setup Instructions

### 1. Clone the Repository (if you haven't already)

```bash
git clone https://github.com/Intelligent-Adaptive-Interventions-Lab/mooclet-engine.git
cd mooclet-engine
```
---
### 2. Environment Configuration

#### Copy `secure.py.example`

Copy the example secure configuration (or modify your existing `secure.py` to include the `docker_local` settings):

```bash
cp mooclet_engine/settings/secure.py.example mooclet_engine/settings/secure.py
```

Edit `secure.py` to use `docker_local` as default for local database:
```python
ACTIVE_DATABASE_CONFIG = 'docker_local'
```
---

#### Copy `docker_local.env.example` env File

These values are used in various spots in the docker setup. No edit needed unless you would like different values.

```bash
cp mooclet_engine/docker_local.env.example mooclet_engine/docker_local.env
```
---

### 3. Run it!

```bash
docker-compose -f docker_local.docker-compose.yml up --build
```

#### To stop the Containers, do:
```bash
docker-compose -f docker_local.docker-compose.yml down
```

### 4. Accessing the Application and get API token

- **Web Application**: http://localhost:8000
- **Admin Panel**: http://localhost:8000/admin
  - Username: `mooclet`
  - Password: `mooclet`

Navigate to `Tokens` to create a token for your API calls.